### PR TITLE
feat: restart docker composed containers unless stopped

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
   influxdb:
     image: influxdb:2
     container_name: influxdb
+    restart: unless-stopped
     hostname: influxdb
     networks:
       - monitoring
@@ -38,6 +39,7 @@ services:
     user: "0"
     image: grafana/grafana:latest
     container_name: grafana
+    restart: unless-stopped
     networks:
       - monitoring
     ports:
@@ -63,6 +65,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: thorflux
+    restart: unless-stopped
     depends_on:
       influxdb:
         condition: service_healthy


### PR DESCRIPTION
Composed docker containers will now restart on error, unless manually stopped.

This should help containers recover from some errors like this:
![image](https://github.com/user-attachments/assets/d1652251-0241-48c5-8556-7c88c6d0fffb)