### PR TITLE
Remove jq dependency, fix token validation error and token exposure risk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN go build -o thorflux
 
 FROM alpine:3.20
 
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    mv jq-linux64 /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq
-
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/thorflux /app/thorflux
 COPY --from=builder /app/influxcli/influx /usr/local/bin/influx

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,20 +43,11 @@ else
 		-p "$INFLUX_USERNAME:$INFLUX_PASSWORD" \
 		-o "$INFLUX_ORG"
 
-	RAW_RESPONSE=$(influx auth create \
+	ALL_ACCESS_TOKEN=$(influx auth create \
 		--org "$INFLUX_ORG" \
 		--read-buckets \
 		--write-buckets \
-		--description "thorflux-api-token" \
-		--json)
-
-	if ! echo "$RAW_RESPONSE" | jq -e . >/dev/null 2>&1; then
-		echo "Error: Failed to create InfluxDB All Access token or invalid JSON response."
-		echo "Response: $RAW_RESPONSE"
-		exit 1
-	fi
-
-	ALL_ACCESS_TOKEN=$(echo "$RAW_RESPONSE" | jq -r '.token')
+		--description "thorflux-api-token" | awk 'NR==2 {print $3}')
 
 	if [[ -z "$ALL_ACCESS_TOKEN" ]]; then
 		echo "Error: All Access token not generated."


### PR DESCRIPTION
In ECS, the token validation is triggered even though the response is clearly valid and contains a working token
![image](https://github.com/user-attachments/assets/1d27d9d8-4535-4269-a750-fa8b46ae6393)

This PR will:
- Remove the redundant jq dependency, might cause issues when internet connectivity is limited
- Fix the aforementioned token validation error
- Fix security risk of token exposure in the logs (the token should not be printed in the logs in plain text)
