### PR TITLE
chore: new execution mode for local thor with dynamic ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 volumes
 .idea/
 .vscode/
+thorflux.log

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ start:
 debug-with-thor-port:
 	@echo "Debugging docker compose with Thor port: $(PORT)"
 	@docker compose up --build -d plugin-builder influxdb grafana --wait
-	@go run . --thor-url=http://127.0.0.1:$(PORT) --influx-token=admin-token --thor-blocks=15 --influx-url=http://127.0.0.1:8086 &
+	@nohup go run . --thor-url=http://127.0.0.1:$(PORT) --influx-token=admin-token --thor-blocks=15 --influx-url=http://127.0.0.1:8086 > thorflux.log 2>&1 &
+	@echo "Logs are being saved to thorflux.log"
 	@open http://localhost:3000/dashboards
 
 stop:
@@ -17,3 +18,5 @@ clean:
 	@echo "Cleaning up..."
 	@docker compose down --remove-orphans --volumes
 	@rm -rf ./volumes
+	-@pkill -f "go run"  # Kill any running go process, ignore if none exists
+	@rm -f thorflux.log

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ clean:
 	@echo "Cleaning up..."
 	@docker compose down --remove-orphans --volumes
 	@rm -rf ./volumes
-	-@pkill -f "go run"  # Kill any running go process, ignore if none exists
+	-@pkill -f "go run . --thor-url"  # Kill any running go process, ignore if none exists
 	@rm -f thorflux.log

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ start:
 	@docker compose up --build -d --wait
 	@open http://localhost:3000/d/bdw67xl69siyo1/influxdb-stats?orgId=1
 
-debug-with-thor-port:
+debug-with-local-thor-port:
 	@echo "Debugging docker compose with Thor port: $(PORT)"
 	@docker compose up --build -d plugin-builder influxdb grafana --wait
 	@nohup go run . --thor-url=http://127.0.0.1:$(PORT) --influx-token=admin-token --thor-blocks=15 --influx-url=http://127.0.0.1:8086 > thorflux.log 2>&1 &

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ start:
 	@docker compose up --build -d --wait
 	@open http://localhost:3000/d/bdw67xl69siyo1/influxdb-stats?orgId=1
 
+debug-with-thor-port:
+	@echo "Debugging docker compose with Thor port: $(PORT)"
+	@docker compose up --build -d plugin-builder influxdb grafana --wait
+	@go run . --thor-url=http://127.0.0.1:$(PORT) --influx-token=admin-token --thor-blocks=15 --influx-url=http://127.0.0.1:8086 &
+	@open http://localhost:3000/dashboards
+
 stop:
 	@echo "Stopping docker compose..."
 	@docker compose down --remove-orphans --volumes

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@ This is a simple tool to send VeChain Thor data to an influxDB instance.
 1. Local Run
 
 ```bash
-make run
-```
-
-1. Docker Only
-
-```bash
-docker compose up
+make start
 ```
 
 2. Debug Mode
@@ -26,4 +20,20 @@ docker compose up
 ```bash
 docker compose up
 go run . --thor-url=https://mainnet.vechain.org --influx-token=admin-token --thor-block=1024
+```
+
+3. Debug mode along with a dynamic Thor port (like hayabusa-e2e tests)
+
+- Extension of 3. Run the desired test in your e2e project and get the Thor port (i.e., 65253), then:
+
+```bash
+make debug-with-thor-port PORT=65253
+```
+
+4. Cleanup
+
+- This will bring down the Docker containers, delete the volumes folder, kill `go run` processes following the format of this project and delete the thorflux log file
+
+```bash
+make clean
 ```

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ docker compose up
 go run . --thor-url=https://mainnet.vechain.org --influx-token=admin-token --thor-block=1024
 ```
 
-3. Debug mode along with a dynamic Thor port (like hayabusa-e2e tests)
+3. Debug mode along with a dynamic local Thor port (like hayabusa-e2e tests)
 
 - Extension of 3. Run the desired test in your e2e project and get the Thor port (i.e., 65253), then:
 
 ```bash
-make debug-with-thor-port PORT=65253
+make debug-with-local-thor-port PORT=65253
 ```
 
 4. Cleanup

--- a/grafana/dashboards/dpos-vtho-dabshboards.json
+++ b/grafana/dashboards/dpos-vtho-dabshboards.json
@@ -105,7 +105,7 @@
       "pluginVersion": "11.6.0",
       "targets": [
         {
-          "query": "from(bucket: \"vechain\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\" and (r[\"_field\"] == \"finalized\" or r[\"_field\"] == \"justified_block\" or r[\"_field\"] == \"liveliness\" or r[\"_field\"] == \"current_block\"))\n  |> drop(columns: [\"chain_tag\", \"block_number\", \"signer\"])",
+          "query": "from(bucket: \"vechain\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\" and (r[\"_field\"] == \"finalized\" or r[\"_field\"] == \"justified_block\" or r[\"_field\"] == \"liveness\" or r[\"_field\"] == \"current_block\"))\n  |> drop(columns: [\"chain_tag\", \"block_number\", \"signer\"])",
           "refId": "A"
         }
       ],

--- a/grafana/dashboards/influx-db-dashboards.json
+++ b/grafana/dashboards/influx-db-dashboards.json
@@ -907,7 +907,7 @@
         "type": "influxdb",
         "uid": "eea2frhqbiuwwa"
       },
-      "description": "Liveliness Chart",
+      "description": "Liveness Chart",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -989,11 +989,11 @@
             "type": "influxdb",
             "uid": "eea2frhqbiuwwa"
           },
-          "query": "from(bucket: \"vechain\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\")\n  |> filter(fn: (r) => r[\"_field\"] == \"liveliness\")\n  |> group(columns: [\"_field\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"vechain\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\")\n  |> filter(fn: (r) => r[\"_field\"] == \"liveness\")\n  |> group(columns: [\"_field\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
-      "title": "Liveliness",
+      "title": "Liveness",
       "type": "timeseries"
     },
     {

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -403,21 +403,21 @@ func (i *DB) appendSlotStats(
 	// if blockTime is within the 15 mins, call to chain for the real finalized block
 	if time.Since(blockTime) < time.Minute*3 {
 		finalized, err := i.thor.Block("finalized")
-		justified, err := i.thor.Block("justified")
 		if err != nil {
 			slog.Error("failed to get finalized block", "error", err)
 			flags["finalized"] = esitmatedFinalized
 			flags["justified_block"] = esitmatedJustified
-			flags["liveliness"] = (currentEpoch - esitmatedFinalized) / 180
+			flags["liveness"] = (currentEpoch - esitmatedFinalized) / 180
 		} else {
+			justified, _ := i.thor.Block("justified")
 			flags["finalized"] = finalized.Number
 			flags["justified_block"] = justified.Number
-			flags["liveliness"] = (currentEpoch - finalized.Number) / 180
+			flags["liveness"] = (currentEpoch - finalized.Number) / 180
 		}
 	} else {
 		flags["finalized"] = esitmatedFinalized
 		flags["justified_block"] = esitmatedJustified
-		flags["liveliness"] = (currentEpoch - esitmatedFinalized) / 180
+		flags["liveness"] = (currentEpoch - esitmatedFinalized) / 180
 	}
 }
 
@@ -450,7 +450,7 @@ func (i *DB) appendEpochStats(block *blocks.JSONExpandedBlock, flags map[string]
 func (i *DB) appendHayabusaEpochStats(block *blocks.JSONExpandedBlock, flags map[string]interface{}, writeAPI api.WriteAPIBlocking) {
 	epoch := block.Number / 180
 	blockInEpoch := block.Number % 180
-	chainTag, err := i.thor.ChainTag()
+	chainTag, _ := i.thor.ChainTag()
 	posData := pos.PoSDataExtractor{
 		Thor: i.thor,
 	}
@@ -496,7 +496,7 @@ func (i *DB) appendHayabusaEpochStats(block *blocks.JSONExpandedBlock, flags map
 	}
 
 	expectedValidator := &thor.Address{}
-	if candidates != nil && len(candidates) > 0 {
+	if len(candidates) > 0 {
 		expectedValidator, err = i.expectedValidator(candidates, block)
 		if err != nil {
 			slog.Error("Cannot extract expected validator", "error", err)
@@ -538,7 +538,7 @@ func (i *DB) appendHayabusaEpochStats(block *blocks.JSONExpandedBlock, flags map
 func (i *DB) appendHayabusaEpochGasStats(block *blocks.JSONExpandedBlock, flags map[string]interface{}, writeAPI api.WriteAPIBlocking) {
 	epoch := block.Number / 180
 	blockInEpoch := block.Number % 180
-	chainTag, err := i.thor.ChainTag()
+	chainTag, _ := i.thor.ChainTag()
 	posData := pos.PoSDataExtractor{
 		Thor: i.thor,
 	}


### PR DESCRIPTION
Added a script so we can run in a single line Thorflux relying on a local Thor instance running in a port created dynamically by the tests (i.e., hayabusa-e2e).

Replaced `liveliness` by `liveness` for better alignment with the dashboards.