### PR TITLE
Add Sync From Block flag

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -64,6 +64,7 @@ services:
       - INFLUX_URL=http://influxdb:8086
       # - INFLUX_TOKEN=admin-token
       - THOR_BLOCKS=200
+      #- SYNC_FROM_BLOCK=22084150
       - INFLUX_USERNAME=admin
       - INFLUX_PASSWORD=password
       - INFLUX_ORG=vechain

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	defaultInfluxDB = "http://localhost:8086"
 	thorFlag        = flag.String("thor-url", defaultThorURL, "thor node URL, (env var: THOR_URL)")
 	blocksFlag      = flag.Uint64("thor-blocks", 360*24*7, "number of blocks to sync (best - <thor-blocks>) (env var: THOR_BLOCKS)")
+	syncBlockFlag   = flag.Uint64("sync-from-block", 0, "start sync from block height - takes precedence to thor-blocks is set (env var: SYNC_FROM_BLOCK)")
 	influxUrlFlag   = flag.String("influx-url", defaultInfluxDB, "influxdb URL, (env var: INFLUX_URL)")
 	influxTokenFlag = flag.String("influx-token", "", "influxdb auth token, (env var: INFLUX_TOKEN)")
 	influxOrg       = flag.String("influx-org", "vechain", "influxdb organization, (env var: INFLUX_ORG)")
@@ -27,7 +28,7 @@ var (
 )
 
 func main() {
-	thorURL, influxURL, influxToken, blocks, err := parseFlags()
+	thorURL, influxURL, influxToken, blocks, syncFromBlock, err := parseFlags()
 	if err != nil {
 		slog.Error("failed to parse flags", "error", err)
 		flag.PrintDefaults()
@@ -39,6 +40,7 @@ func main() {
 		"influx-org", *influxOrg,
 		"influx-bucket", *influxBucket,
 		"blocks", blocks,
+		"sync-from-block", syncFromBlock,
 	)
 
 	thor := thorclient.New(thorURL)
@@ -46,6 +48,17 @@ func main() {
 	if err != nil {
 		slog.Error("failed to create influxdb", "error", err)
 		os.Exit(1)
+	}
+
+	// if set syncFromBlock will override the thorBlocks number
+	if syncFromBlock != 0 {
+		block, err := thor.Block("best")
+		if err != nil {
+			slog.Error("failed to retrieve best block", "error", err)
+			os.Exit(1)
+		}
+		blocks = block.Number - uint32(syncFromBlock)
+		slog.Info("syncing from specified block", "syncFromBlock", syncFromBlock, "blocks", blocks)
 	}
 
 	ctx := exitContext()
@@ -68,14 +81,14 @@ func main() {
 	<-ctx.Done()
 }
 
-func parseFlags() (string, string, string, uint32, error) {
+func parseFlags() (string, string, string, uint32, uint64, error) {
 	if err := envflag.Parse(); err != nil {
-		return "", "", "", 0, err
+		return "", "", "", 0, 0, err
 	}
 
 	influxToken := *influxTokenFlag
 	if influxToken == "" {
-		return "", "", "", 0, errors.New("--influx-token or INFLUX_DB_TOKEN is required")
+		return "", "", "", 0, 0, errors.New("--influx-token or INFLUX_DB_TOKEN is required")
 	}
 
 	thorURL := *thorFlag
@@ -88,9 +101,11 @@ func parseFlags() (string, string, string, uint32, error) {
 		slog.Warn("influxdb URL not set via flag or env, using default", "url", defaultInfluxDB)
 	}
 
+	syncFromBlock := *syncBlockFlag
+
 	blocks := *blocksFlag
 
-	return thorURL, influxURL, influxToken, uint32(blocks), nil
+	return thorURL, influxURL, influxToken, uint32(blocks), syncFromBlock, nil
 }
 
 func exitContext() context.Context {

--- a/pubsub/publisher.go
+++ b/pubsub/publisher.go
@@ -219,7 +219,7 @@ func (s *Publisher) shouldQuit() bool {
 		slog.Error("failed to get best block", "error", err)
 		return false
 	}
-	if best.Number-s.previous().Number > 1000 {
+	if best.Number-s.previous().Number > 100 {
 		return false
 	}
 	return true


### PR DESCRIPTION
Adds a `sync-from-block` flag that overrides the existing `thor-blocks` flags when specified.

This allows to sync from a particular block, helpful for node-ops deployment.