### PR TITLE
chore(workers): logging panics

### DIFF
--- a/pubsub/worker_pool.go
+++ b/pubsub/worker_pool.go
@@ -81,6 +81,16 @@ func (wp *WorkerPool) worker(id int) {
 
 // processTask executes a single task with error handling and metrics
 func (wp *WorkerPool) processTask(task Task, workerID int) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Worker panic recovered", 
+				"worker_id", workerID, 
+				"event_type", task.EventType,
+				"block_number", task.Event.Block.Number,
+				"panic", r)
+		}
+	}()
+
 	start := time.Now()
 
 	slog.Debug("Processing task",


### PR DESCRIPTION
A task involves some stages and a panic can be raised at some point. It should not stop the worker but at least it should be logged.