### PR TITLE
Fix: number of validators panel

### DIFF
--- a/grafana/dashboards/network-overview.json
+++ b/grafana/dashboards/network-overview.json
@@ -324,7 +324,7 @@
             "type": "influxdb",
             "uid": "B87265B08D314AF"
           },
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\" )\n  |> keep(columns: [\"signer\"]) \n  |> group()\n  |> distinct(column: \"signer\")\n  |> count()",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"block_signer\" )\n  |> filter(fn: (r) => r[\"_measurement\"] == \"block_stats\" )\n  |> keep(columns: [\"signer\"]) \n  |> group()\n  |> distinct(column: \"signer\")\n  |> count()",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Descrpition
Updated query to reflect the active number of validators in a time period. 
[Link ](https://g-98e9973c94.grafana-workspace.eu-west-1.amazonaws.com/d/befstdrjprz7kk/network-overview?orgId=1&var-bucket=mainnet&from=now-24h&to=now)to dashboard